### PR TITLE
Rename executable package for clarity

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -1,0 +1,13 @@
+This is where your executables will go. Each executable should be put into a separate package, corresponsing to the final artifact's name (e.g. `webservice`, `adminservice`, `cli`, etc) . Inside the package, create a main execution point: typically, this will be a `main.go` file containing a `main` function. You can have as many executables in your app as you like.
+
+```
+├── cmd
+│   ├── adminservice
+│   │   └── main.go
+│   ├── cli
+│   │   └── main.go
+│   ├── cronjobs
+│   │   └── main.go
+│   └── webservice
+│       └── main.go
+```

--- a/cmd/webservice/main.go
+++ b/cmd/webservice/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/go-chi/chi"
 	"github.com/preslavrachev/go-service-template/config"
-	"github.com/preslavrachev/go-service-template/config/myservice"
+	"github.com/preslavrachev/go-service-template/config/webservice"
 	http2 "github.com/preslavrachev/go-service-template/http"
 	"github.com/preslavrachev/go-service-template/persistence"
 	"log"
@@ -12,12 +12,12 @@ import (
 
 func main() {
 
-	db := &persistence.DB{DB: myservice.SetUpDB()}
+	db := &persistence.DB{DB: webservice.SetUpDB()}
 	appContext := &config.AppContext{
 		Server: http2.NewServer(chi.NewRouter()),
 		DB:     db,
 	}
-	myservice.SetUpRoutes(appContext)
+	webservice.SetUpRoutes(appContext)
 
 	log.Fatal(http.ListenAndServe(":8080", appContext.Server.Router()))
 }

--- a/config/webservice/db.go
+++ b/config/webservice/db.go
@@ -1,4 +1,4 @@
-package myservice
+package webservice
 
 import (
 	"github.com/jinzhu/gorm"

--- a/config/webservice/route.go
+++ b/config/webservice/route.go
@@ -1,4 +1,4 @@
-package myservice
+package webservice
 
 import (
 	"github.com/go-chi/chi"


### PR DESCRIPTION
Keeping the executable package name the same as the one of the whole project might have been confusing. This PR changes it in favor of `webservice`, in order to signify that there can be multiple employable artifacts inside the same project.